### PR TITLE
Fix reporting missing view name

### DIFF
--- a/src/Util/View.php
+++ b/src/Util/View.php
@@ -73,7 +73,7 @@ class View
         
         if (empty($view_path)) {
             if (self::$report_errors) {
-                die('View not found: ' . $view_path);
+                die('View not found: ' . $path);
             }
             return null;
         }


### PR DESCRIPTION
Echoing the empty `$view_path` isn't very useful, since it's empty. This changes it to report the original view name requested.